### PR TITLE
Seed database with 44 real open-source technologies

### DIFF
--- a/app/controllers/technologies_controller.rb
+++ b/app/controllers/technologies_controller.rb
@@ -21,6 +21,6 @@ class TechnologiesController < ApplicationController
   private
 
   def technology_params
-    params.expect(technology: [ :name, :category, :url ])
+    params.expect(technology: [ :name, :github_url ])
   end
 end

--- a/app/models/technology.rb
+++ b/app/models/technology.rb
@@ -1,8 +1,9 @@
 class Technology < ApplicationRecord
-    has_many :votes, dependent: :destroy
-    validates :name, presence: true, uniqueness: true
+  has_many :votes, dependent: :destroy
+  validates :name, presence: true, uniqueness: true
+  validates :github_url, format: { with: %r{\Ahttps://github.com/[\w.-]+/[\w.-]+\z}, message: "must be a valid GitHub repository URL" }, allow_blank: true
 
-    def net_votes
-        votes.sum(:vote)
-    end
+  def net_votes
+    votes.sum(:vote)
+  end
 end

--- a/app/views/technologies/_form.html.erb
+++ b/app/views/technologies/_form.html.erb
@@ -1,8 +1,13 @@
 <%= form_with model: technology do |form| %>
   <div>
     <%= form.label :name %>
-      <%= form.text_field :name %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div>
+    <%= form.label :github_url %>
+    <%= form.text_field :github_url, placeholder: "https://github.com/owner/repo" %>
   </div>
 
   <%= form.submit %>
-    <% end %>
+<% end %>

--- a/app/views/technologies/index.html.erb
+++ b/app/views/technologies/index.html.erb
@@ -6,12 +6,8 @@
 <p>
     Follow the progress here on <a href="https://github.com/gianniacquisto/code-rank">GitHub</a>.
 </p>
-<p>
-    More information will follow!
-</p> 
-<h2>List of Open Source technologies:</h2>
 
-<p>Below you can find the name, category and GitHub link to the technology.</p>
+<h2>List of Open Source technologies:</h2>
 
 <div id="technologies">
   <ul class="project-list">
@@ -21,7 +17,9 @@
               
           <div>
             <h3><%= technology.name %></h3>
-            <p><strong>GitHub:</strong> <a href="https://github.com/<%= technology.name %>">Link</a></p>
+            <% if technology.github_url %>
+              <p><strong>GitHub:</strong> <a href="<%= technology.github_url %>"><%= technology.github_url %></a></p>
+            <% end %>
             <p><strong>Votes:</strong> <%= technology.net_votes %></p>
           </div>
           <div>

--- a/bin/seed-production
+++ b/bin/seed-production
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Seed the production database with open-source technologies.
+# Run this ONCE after deploying the migration:
+#   bin/seed-production
+set -euo pipefail
+
+echo "Seeding production database with open-source technologies..."
+bin/kamal app exec --ruby 'rails db:seed'
+echo "Done."

--- a/db/migrate/20260621143104_add_github_url_to_technologies.rb
+++ b/db/migrate/20260621143104_add_github_url_to_technologies.rb
@@ -1,0 +1,6 @@
+class AddGithubUrlToTechnologies < ActiveRecord::Migration[8.1]
+  def change
+    add_column :technologies, :github_url, :string
+    add_index :technologies, :github_url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,37 +10,39 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_21_090946) do
-  create_table "technologies", force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
+ActiveRecord::Schema[8.1].define(version: 2026_06_21_143104) do
   create_table "sessions", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.string "ip_address"
-    t.string "user_agent"
     t.datetime "created_at", null: false
+    t.string "ip_address"
     t.datetime "updated_at", null: false
+    t.string "user_agent"
+    t.integer "user_id", null: false
     t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
+  create_table "technologies", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "github_url"
+    t.string "name"
+    t.datetime "updated_at", null: false
+    t.index ["github_url"], name: "index_technologies_on_github_url"
+  end
+
   create_table "users", force: :cascade do |t|
+    t.boolean "adminFlag"
+    t.datetime "created_at", null: false
     t.string "email_address", null: false
     t.string "password_digest", null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "adminFlag"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
   create_table "votes", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "vote"
     t.integer "technology_id", null: false
+    t.datetime "updated_at", null: false
     t.integer "user_id", null: false
+    t.integer "vote"
     t.index ["technology_id"], name: "index_votes_on_technology_id"
     t.index ["user_id"], name: "index_votes_on_user_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,71 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+# Populates the database with real open-source technologies.
+# Safe to run multiple times — uses find_or_create_by for idempotency.
+# Usage: bin/rails db:seed
+
+TECHNOLOGIES = [
+  # Frameworks
+  { name: "rails", github_url: "https://github.com/rails/rails" },
+  { name: "django", github_url: "https://github.com/django/django" },
+  { name: "fastapi", github_url: "https://github.com/fastapi/fastapi" },
+  { name: "express", github_url: "https://github.com/expressjs/express" },
+  { name: "next", github_url: "https://github.com/vercel/next.js" },
+  { name: "spring-boot", github_url: "https://github.com/spring-projects/spring-boot" },
+  { name: "laravel", github_url: "https://github.com/laravel/laravel" },
+  { name: "flask", github_url: "https://github.com/pallets/flask" },
+  { name: "react", github_url: "https://github.com/facebook/react" },
+  { name: "vue", github_url: "https://github.com/vuejs/core" },
+
+  # Languages & Runtimes
+  { name: "typescript", github_url: "https://github.com/microsoft/TypeScript" },
+  { name: "python", github_url: "https://github.com/python/cpython" },
+  { name: "rust", github_url: "https://github.com/rust-lang/rust" },
+  { name: "go", github_url: "https://github.com/golang/go" },
+  { name: "node", github_url: "https://github.com/nodejs/node" },
+  { name: "deno", github_url: "https://github.com/denoland/deno" },
+  { name: "bun", github_url: "https://github.com/oven-sh/bun" },
+
+  # Databases
+  { name: "postgresql", github_url: "https://github.com/postgres/postgres" },
+  { name: "sqlite", github_url: "https://github.com/sqlite/sqlite" },
+  { name: "redis", github_url: "https://github.com/redis/redis" },
+  { name: "mongodb", github_url: "https://github.com/mongodb/mongo" },
+  { name: "mysql", github_url: "https://github.com/mysql/mysql-server" },
+
+  # DevOps & Infrastructure
+  { name: "docker", github_url: "https://github.com/moby/moby" },
+  { name: "kubernetes", github_url: "https://github.com/kubernetes/kubernetes" },
+  { name: "terraform", github_url: "https://github.com/hashicorp/terraform" },
+  { name: "nginx", github_url: "https://github.com/nginx/nginx" },
+  { name: "traefik", github_url: "https://github.com/traefik/traefik" },
+
+  # CI/CD & Monitoring
+  { name: "github-actions", github_url: "https://github.com/actions/runner" },
+  { name: "jenkins", github_url: "https://github.com/jenkinsci/jenkins" },
+  { name: "grafana", github_url: "https://github.com/grafana/grafana" },
+  { name: "prometheus", github_url: "https://github.com/prometheus/prometheus" },
+
+  # Tooling & Linters
+  { name: "pre-commit", github_url: "https://github.com/pre-commit/pre-commit" },
+  { name: "black", github_url: "https://github.com/psf/black" },
+  { name: "eslint", github_url: "https://github.com/eslint/eslint" },
+  { name: "prettier", github_url: "https://github.com/prettier/prettier" },
+  { name: "tailwindcss", github_url: "https://github.com/tailwindlabs/tailwindcss" },
+  { name: "vite", github_url: "https://github.com/vitejs/vite" },
+  { name: "webpack", github_url: "https://github.com/webpack/webpack" },
+  { name: "bundler", github_url: "https://github.com/rubygems/bundler" },
+
+  # Testing
+  { name: "pytest", github_url: "https://github.com/pytest-dev/pytest" },
+  { name: "jest", github_url: "https://github.com/jestjs/jest" },
+  { name: "rspec", github_url: "https://github.com/rspec/rspec-rails" },
+  { name: "cypress", github_url: "https://github.com/cypress-io/cypress" },
+  { name: "playwright", github_url: "https://github.com/microsoft/playwright" }
+]
+
+TECHNOLOGIES.each do |tech|
+  Technology.find_or_create_by!(name: tech[:name]) do |t|
+    t.github_url = tech[:github_url]
+  end
+end
+
+puts "Seeded #{TECHNOLOGIES.size} technologies."


### PR DESCRIPTION
## Changes

- **Migration**: Add `github_url` column to `technologies` table with index
- **Seeds**: Populate `db/seeds.rb` with 44 real open-source projects organized by category:
  - Frameworks (Rails, Django, FastAPI, Express, Next.js, Spring Boot, Laravel, Flask, React, Vue)
  - Languages & Runtimes (TypeScript, Python, Rust, Go, Node, Deno, Bun)
  - Databases (PostgreSQL, SQLite, Redis, MongoDB, MySQL)
  - DevOps & Infrastructure (Docker, Kubernetes, Terraform, Nginx, Traefik)
  - CI/CD & Monitoring (GitHub Actions, Jenkins, Grafana, Prometheus)
  - Tooling & Linters (pre-commit, Black, ESLint, Prettier, TailwindCSS, Vite, Webpack, Bundler)
  - Testing (pytest, Jest, RSpec, Cypress, Playwright)
- **View**: Update index to display `github_url` instead of constructing from name
- **Form**: Add `github_url` field to the technology creation form
- **Controller**: Clean up stale `category`/`url` params, permit `github_url`
- **Model**: Add `github_url` format validation

## Testing

- `bin/rails test` passes
- `bin/rails db:seed` is idempotent (safe to run multiple times)
- `bundle exec rubocop` clean

## Related

Closes #77