### PR TITLE
fix: sitemap generation and daily scheduling

### DIFF
--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -10,6 +10,10 @@
 #     schedule: at 5am every day
 
 production:
+  regenerate_sitemap:
+    class: SitemapRefreshJob
+    queue: default
+    schedule: at 2am every day
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "technology"
+
 # Root page
 SitemapGenerator::Sitemap.add root_path, priority: 1.0, changefreq: "daily"
 


### PR DESCRIPTION
## Changes

- **Add `require "technology"` to `config/sitemap.rb`**
  `sitemap_generator` runs outside Rails' autoloading context, so the `Technology` model wasn't available. This caused 0 links in the sitemap despite 44 technologies in the DB.

- **Register `SitemapRefreshJob` in `config/recurring.yml`**
  The job class existed but was never scheduled. Now it runs daily at 2am to keep the sitemap in sync.

## What's live after deploy

- `https://code-rank.com/sitemap/sitemap.xml` — lists root + all technology pages
- `robots.txt` — already points to the sitemap
- `<link rel="sitemap">` tag in layout — already present
- Daily auto-refresh at 2am via Solid Queue recurring job